### PR TITLE
Potential fix for code scanning alert no. 7: Uncontrolled data used in path expression

### DIFF
--- a/Network/file_transfer_server/java/com/server/Server.java
+++ b/Network/file_transfer_server/java/com/server/Server.java
@@ -33,6 +33,10 @@ public class Server {
     }
 
     private static void receiveFile(String fileName) throws Exception{
+        // Validate fileName: no path separators or parent dir references allowed
+        if (fileName.contains("..") || fileName.contains("/") || fileName.contains("\\")) {
+            throw new IllegalArgumentException("Invalid filename");
+        }
         int bytes = 0;
         FileOutputStream fileOutputStream = new FileOutputStream(fileName);
 


### PR DESCRIPTION
Potential fix for [https://github.com/s3bu7i/linux-network-win-tools/security/code-scanning/7](https://github.com/s3bu7i/linux-network-win-tools/security/code-scanning/7)

To fix the problem, we must prevent users from controlling arbitrary path expressions when uploading or creating files on the server. This is achieved by validating the user-supplied `fileName` before it is used. The best practice here depends on whether only the file name (no directories) is meant to be allowed (most common for user file uploads). Since the current code does `readUTF()` into `fileName` and then writes with that name, it's implied that directory traversal is not intended or safe—so the fix should restrict file names to a single file component, with no path separators (`/`, `\`) or `".."` segments.

The fix is to add a check at the start of the `receiveFile` method: If `fileName` contains `..`, `/`, or `\`, throw an exception. Optionally, one can define a base upload directory and join the (validated) filename to it for further safety, but as per the supplied code, the simplest filename-component validation suffices.

**What needs to change:**
- Add a check at the top of `receiveFile` to reject invalid file names.
- Throw an exception (as in the standard example) if the name is invalid, preventing the dangerous file operation.
- Optionally, add a base directory (e.g., `uploads/`) if further hardening is desired, but this is outside the shown code and would change file storage semantics.

**What is needed:**
- No new imports required, as `String.contains` is used.
- Add the input validation at the beginning of the `receiveFile` method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
