### PR TITLE
Potential fix for code scanning alert no. 5: Flask app is run in debug mode

### DIFF
--- a/Linux/remote_command_excution/main.py
+++ b/Linux/remote_command_excution/main.py
@@ -101,5 +101,5 @@ def command_form():
 
 
 if __name__ == '__main__':
-    # Running the Flask app in debug mode
-    app.run(debug=True, host='0.0.0.0', port=5000)
+    # Running the Flask app (debug mode disabled)
+    app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
Potential fix for [https://github.com/s3bu7i/linux-network-win-tools/security/code-scanning/5](https://github.com/s3bu7i/linux-network-win-tools/security/code-scanning/5)

To fix the problem, disable debug mode by setting `debug=False` or simply by omitting the `debug` argument from the `app.run()` call (since it defaults to `False`). The change should be made in the `if __name__ == '__main__':` block, specifically on line 105. Do not otherwise modify the app's runtime behavior. If development-mode debugging is important, it is best practice to base the value of `debug` on an environment variable or configuration rather than hardcoding, but the most direct secure fix is to run with `debug=False` (or remove the argument).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
