### PR TITLE
Potential fix for code scanning alert no. 3: Binding a socket to all network interfaces

### DIFF
--- a/Linux/netcat_tool/netcat.py
+++ b/Linux/netcat_tool/netcat.py
@@ -75,9 +75,9 @@ def chat_client(target_ip, port):
             print(f"{target_ip}: {response}")
 
 # Function to execute remote commands
-def remote_shell_server(port):
+def remote_shell_server(port, listen_ip="127.0.0.1"):
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("", port))
+        s.bind((listen_ip, port))
         s.listen(1)
         conn, addr = s.accept()
         print(f"Remote shell connection from {addr}")


### PR DESCRIPTION
Potential fix for [https://github.com/s3bu7i/linux-network-win-tools/security/code-scanning/3](https://github.com/s3bu7i/linux-network-win-tools/security/code-scanning/3)

To fix the problem, change the server-side code so it does **not** bind to all interfaces by default.  
The safest remediation is to add a parameter to `remote_shell_server` – e.g., `listen_ip` – so the calling code must explicitly specify which IP/interface to bind to (defaulting to `'127.0.0.1'` for local-only). In the code block, replace `s.bind(("", port))` with `s.bind((listen_ip, port))`. This change only affects the interface binding and preserves all existing logic.

Because we can only edit code we've been shown, the change will be strictly within `remote_shell_server` and usages in the code shown above; if nothing else has shown function calls/usage in the lines above, we can simply update the `remote_shell_server` definition and its bind call.

If importing or using the tool via CLI or another mechanism, the user will need to provide the IP/interface to bind to.

No new imports are necessary for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
